### PR TITLE
fix: snap runtime issues in configure hook and run-registry

### DIFF
--- a/scripts/run-registry
+++ b/scripts/run-registry
@@ -1,3 +1,10 @@
 #!/bin/bash
 
-"${SNAP}/bin/registry" serve "${SNAP_COMMON}/config.yaml"
+set -eu
+
+if [ ! -f "${SNAP_COMMON}/config.yaml" ]; then
+    echo "error: config file not found at ${SNAP_COMMON}/config.yaml" >&2
+    exit 1
+fi
+
+exec "${SNAP}/bin/registry" serve "${SNAP_COMMON}/config.yaml"

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-"${SNAP}/bin/mkdir" -p "$SNAP_COMMON/data"
+set -e
+
+mkdir -p "$SNAP_COMMON/data"
 
 if [ ! -f "${SNAP_COMMON}/config.yaml" ]; then
 	echo "---


### PR DESCRIPTION
## Summary

- Add `set -e` to configure hook so failures are surfaced
- Add `exec` to run-registry so snapd manages the registry process directly
- Add `set -eu` and config file existence check to run-registry for early failure with clear errors