### PR TITLE
fix: metadata and documentation corrections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Registry snap
 
-This is a snapcraft package for [Docker Registry](https://github.com/docker/distribution)
+This is a snapcraft package for [CNCF Distribution](https://github.com/distribution/distribution) (OCI image registry)
 
 ## Usage
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -6,7 +6,7 @@ description: |
   Simple snap package to set up a local OCI image registry using the CNCF
   Distribution project from https://github.com/distribution/distribution/.
 source-code: https://github.com/canonical/registry-snap
-# TODO: define license
+license: Apache-2.0
 
 grade: stable
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,7 @@ title: Registry
 version: '3.1.0'
 summary: Local OCI Image Registry
 description: |
-  Simple snap package to set up a local OCI rmage registry using the CNCF
+  Simple snap package to set up a local OCI image registry using the CNCF
   Distribution project from https://github.com/distribution/distribution/.
 source-code: https://github.com/canonical/registry-snap
 # TODO: define license


### PR DESCRIPTION
## Summary

- Fix typo in snap description (`rmage` -> `image`)
- Add `license: Apache-2.0` field to snapcraft.yaml (was a TODO)
- Update README upstream link from deprecated `docker/distribution` to `distribution/distribution`