### PR TITLE
fix: e2e test issues

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -77,4 +77,4 @@ jobs:
           timeout 60 sh -c 'until sg docker -c "docker info" > /dev/null 2>&1; do sleep 1; done'
 
       - name: Run e2e tests
-        run: sg docker -c "bash ./tests/push.sh 127.0.0.0"
+        run: sg docker -c "bash ./tests/push.sh 127.0.0.1"

--- a/tests/push.sh
+++ b/tests/push.sh
@@ -8,9 +8,9 @@ if [ -z "$1" ]; then
 fi
 
 REGISTRY="$1"
-TIMEOUT=5
+TIMEOUT=12
 while [ $TIMEOUT -gt 0 ]; do
-    STATUS=$(curl -s -o /dev/null -w '%{http_code}' "http://${REGISTRY}:5000/v2/")
+    STATUS=$(curl --connect-timeout 3 --max-time 5 -s -o /dev/null -w '%{http_code}' "http://${REGISTRY}:5000/v2/")
     echo $STATUS
     if [ $STATUS -eq 200 ] || [ $STATUS -eq 401 ]; then
         break
@@ -20,7 +20,7 @@ while [ $TIMEOUT -gt 0 ]; do
 done
 
 if [ $TIMEOUT -eq 0 ]; then
-    echo "Registry cannot be available within one minute."
+    echo "Registry not available within one minute."
     exit 1
 fi
 

--- a/tests/push.sh
+++ b/tests/push.sh
@@ -2,9 +2,15 @@
 
 set +e
 
+if [ -z "$1" ]; then
+    echo "Usage: $0 <registry-host>"
+    exit 1
+fi
+
+REGISTRY="$1"
 TIMEOUT=5
 while [ $TIMEOUT -gt 0 ]; do
-    STATUS=$(curl --insecure -s -o /dev/null -w '%{http_code}' http://localhost:5000/v2/)
+    STATUS=$(curl -s -o /dev/null -w '%{http_code}' "http://${REGISTRY}:5000/v2/")
     echo $STATUS
     if [ $STATUS -eq 200 ] || [ $STATUS -eq 401 ]; then
         break
@@ -21,6 +27,6 @@ fi
 set -e
 
 docker pull hello-world:latest
-docker tag hello-world:latest $1:5000/distribution/hello-world:latest
-docker push $1:5000/distribution/hello-world:latest
-docker pull $1:5000/distribution/hello-world:latest
+docker tag hello-world:latest "${REGISTRY}:5000/distribution/hello-world:latest"
+docker push "${REGISTRY}:5000/distribution/hello-world:latest"
+docker pull "${REGISTRY}:5000/distribution/hello-world:latest"


### PR DESCRIPTION
## Summary

- Fix `127.0.0.0` -> `127.0.0.1` typo in e2e workflow
- Add argument validation and proper quoting in `tests/push.sh`
- Use the registry host argument for the health check curl (was hardcoded to `localhost`)