### PR TITLE
fix: use track-scoped token for snap track releases

### DIFF
--- a/.github/workflows/release_snap_track.yaml
+++ b/.github/workflows/release_snap_track.yaml
@@ -68,7 +68,7 @@ jobs:
       track: ${{ needs.validate-tag.outputs.track }}
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
-      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN_EDGE }}
+      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN_TRACK_EDGE }}
     permissions:
       actions: read  # Needed for GitHub API call to get workflow version
       contents: write  # Needed to create git tags


### PR DESCRIPTION
## Summary
- Use `SNAP_STORE_TOKEN_TRACK_EDGE` secret (scoped to `*/edge`) for the tag-triggered track release workflow
- The existing `SNAP_STORE_TOKEN_EDGE` is scoped to `latest/edge` only, which fails when releasing to `X.Y/edge` tracks